### PR TITLE
Removal of '[' and ']' from char blacklist of vfs:real module

### DIFF
--- a/eyeOS/system/services/vfs/modules/real.eyecode
+++ b/eyeOS/system/services/vfs/modules/real.eyecode
@@ -26,7 +26,7 @@ Copyright © 2005 - 2010 eyeos Team (team@eyeos.org)
 //
 
 global $charBlackList;
-$charBlackList = array("/","\\","<",">","[","]","htaccess","php.ini");
+$charBlackList = array("/","\\","<",">","htaccess","php.ini");
 
 
 /**


### PR DESCRIPTION
- After about three months of use, Guzle has reported back no problems with these characters being removed from the blacklist of this module
- As noted in the forum thread, these characters should not be removed from the 'Virtual' module, only the 'Real' module.

Please see: http://forums.oneye-project.org/viewtopic.php?pid=1409
