### PR TITLE
Tweaks to eyeVisor's getFile() function

### DIFF
--- a/system/apps/eyeVisor/events.eyecode
+++ b/system/apps/eyeVisor/events.eyecode
@@ -53,15 +53,16 @@ function eyeVisor_on_getFile($params = null) {
 		return false;
 	}
 	
-	$handler = vfs('real_open', array($file, 'r'));
+	$real = vfs('getRealName', array($file));
+	$handler = vfs('real_open', array($real, 'r'));
 	$bytes = fread($handler, 5);
 	fclose($handler);
 	
 	if ($bytes == '<html') {
-		$content = /* utf8 */ preg_replace('/<img[^\/]*\/>/i', '', file_get_contents($file));
+		$content = /* utf8 */ preg_replace('/<img[^\/]*\/>/i', '', file_get_contents($real));
 	} else {
-		$temp = um('getCurrentUserDir') . '/' . TMP_DIR . '/' . $myPid . /* utf8 */ strrchr($file, '.');
-		vfs('real_copy', array(vfs('getRealName', array($file)), $temp));
+		$temp = um('getCurrentUserDir') . TMP_USER_DIR . '/' . $myPid . /* utf8 */ strrchr($file, '.');
+		vfs('real_copy', array($real, $temp));
 		
 		if (eyeConverter('convert', array($temp, $temp . '.html', 'html', 1))) {
 			$content = vfs('real_getFileContent', array($temp . '.html'));


### PR DESCRIPTION
- vfs('real_open') cannot be passed the filename of a virtual file as it will be unable to find it.
- The constant TMP_DIR does not exist, but TMP_USER_DIR does.
